### PR TITLE
move consumer-added before pipeline starts playing

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -1728,6 +1728,8 @@ impl WebRTCSink {
             state.navigation_handler = Some(NavigationEventHandler::new(&element, &webrtcbin));
         }
 
+        element.emit_by_name::<()>("consumer-added", &[&peer_id, &webrtcbin]);
+
         pipeline.set_state(gst::State::Playing).map_err(|err| {
             WebRTCSinkError::ConsumerPipelineError {
                 peer_id: peer_id.to_string(),
@@ -1738,7 +1740,6 @@ impl WebRTCSink {
         state.consumers.insert(peer_id.to_string(), consumer);
 
         drop(state);
-        element.emit_by_name::<()>("consumer-added", &[&peer_id, &webrtcbin]);
 
         Ok(())
     }


### PR DESCRIPTION
As described in https://github.com/centricular/webrtcsink/issues/25#issuecomment-1048465601

Thanks - what I discovered is that things seem to be happy if `create-data-channel` happens before the pipeline starts playing, but `consumer-added` only occurs after the pipeline is playing, and that seems to create a race condition that is easily reproducible with localhost connections. Moving `consumer-added` to just before pipeline starts playing eliminates the issue even with localhost connections.