### PR TITLE
protocol: allow registering with a display name

### DIFF
--- a/plugins/src/signaller/imp.rs
+++ b/plugins/src/signaller/imp.rs
@@ -90,7 +90,9 @@ impl Signaller {
         });
 
         websocket_sender
-            .send(p::IncomingMessage::Register(p::RegisterMessage::Producer))
+            .send(p::IncomingMessage::Register(p::RegisterMessage::Producer {
+                display_name: element.property("display-name"),
+            }))
             .await?;
 
         let element_clone = element.downgrade();
@@ -104,7 +106,7 @@ impl Signaller {
                             if let Ok(msg) = serde_json::from_str::<p::OutgoingMessage>(&msg) {
                                 match msg {
                                     p::OutgoingMessage::Registered(
-                                        p::RegisteredMessage::Producer { peer_id },
+                                        p::RegisteredMessage::Producer { peer_id, .. },
                                     ) => {
                                         gst_info!(
                                             CAT,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -8,13 +8,29 @@ use serde::{Deserialize, Serialize};
 pub enum RegisteredMessage {
     /// Registered as a producer
     #[serde(rename_all = "camelCase")]
-    Producer { peer_id: String },
+    Producer {
+        peer_id: String,
+        display_name: Option<String>,
+    },
     /// Registered as a consumer
     #[serde(rename_all = "camelCase")]
-    Consumer { peer_id: String },
+    Consumer {
+        peer_id: String,
+        display_name: Option<String>,
+    },
     /// Registered as a listener
     #[serde(rename_all = "camelCase")]
-    Listener { peer_id: String },
+    Listener {
+        peer_id: String,
+        display_name: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Peer {
+    pub id: String,
+    pub display_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -26,10 +42,16 @@ pub enum OutgoingMessage {
     Registered(RegisteredMessage),
     /// Notifies listeners that a producer was registered
     #[serde(rename_all = "camelCase")]
-    ProducerAdded { peer_id: String },
+    ProducerAdded {
+        peer_id: String,
+        display_name: Option<String>,
+    },
     /// Notifies listeners that a producer was removed
     #[serde(rename_all = "camelCase")]
-    ProducerRemoved { peer_id: String },
+    ProducerRemoved {
+        peer_id: String,
+        display_name: Option<String>,
+    },
     /// Instructs a peer to generate an offer
     #[serde(rename_all = "camelCase")]
     StartSession { peer_id: String },
@@ -39,7 +61,7 @@ pub enum OutgoingMessage {
     /// Messages directly forwarded from one peer to another
     Peer(PeerMessage),
     /// Provides the current list of consumer peers
-    List { producers: Vec<String> },
+    List { producers: Vec<Peer> },
     /// Notifies that an error occurred with the peer's current session
     Error { details: String },
 }
@@ -50,11 +72,23 @@ pub enum OutgoingMessage {
 /// Register with a peer type
 pub enum RegisterMessage {
     /// Register as a producer
-    Producer,
+    #[serde(rename_all = "camelCase")]
+    Producer {
+        #[serde(default)]
+        display_name: Option<String>,
+    },
     /// Register as a consumer
-    Consumer,
+    #[serde(rename_all = "camelCase")]
+    Consumer {
+        #[serde(default)]
+        display_name: Option<String>,
+    },
     /// Register as a listener
-    Listener,
+    #[serde(rename_all = "camelCase")]
+    Listener {
+        #[serde(default)]
+        display_name: Option<String>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/signalling/src/server/mod.rs
+++ b/signalling/src/server/mod.rs
@@ -52,7 +52,7 @@ impl Server {
                 match serde_json::from_str::<I>(&msg) {
                     Ok(msg) => Some((peer_id, Some(msg))),
                     Err(err) => {
-                        warn!("Failed to parse incoming message: {}", err);
+                        warn!("Failed to parse incoming message: {} ({})", err, msg);
                         None
                     }
                 }

--- a/www/webrtc.js
+++ b/www/webrtc.js
@@ -240,6 +240,8 @@ function Session(our_id, peer_id, closed_callback) {
         var videoTracks = event.stream.getVideoTracks();
         var audioTracks = event.stream.getAudioTracks();
 
+        console.log(videoTracks);
+
         if (videoTracks.length > 0) {
             console.log('Incoming stream: ' + videoTracks.length + ' video tracks and ' + audioTracks.length + ' audio tracks');
             this.getVideoElement().srcObject = event.stream;
@@ -340,9 +342,16 @@ function session_closed(peer_id) {
     sessions[peer_id] = null;
 }
 
-function addPeer(peer_id) {
+function addPeer(peer_id, display_name) {
+    console.log("Display name: ", display_name);
+
     var nav_ul = document.getElementById("camera-list");
-    var li_str = '<li id="peer-' + peer_id + '"><button class="button button1">' + peer_id + '</button></li>'
+
+    if (display_name == null) {
+        var li_str = '<li id="peer-' + peer_id + '"><button class="button button1">' + peer_id + '</button></li>';
+    } else {
+        var li_str = '<li id="peer-' + peer_id + '"><button class="button button1">' + display_name + '</button></li>';
+    }
 
     nav_ul.insertAdjacentHTML('beforeend', li_str);
     var li = document.getElementById("peer-" + peer_id);
@@ -384,10 +393,10 @@ function onServerMessage(event) {
     } else if (msg.type == "list") {
         clearPeers();
         for (i = 0; i < msg.producers.length; i++) {
-            addPeer(msg.producers[i]);
+            addPeer(msg.producers[i].id, msg.producers[i].displayName);
         }
     } else if (msg.type == "producerAdded") {
-        addPeer(msg.peerId);
+        addPeer(msg.peerId, msg.displayName);
     } else if (msg.type == "producerRemoved") {
         var li = document.getElementById("peer-" + msg.peerId);
         li.parentNode.removeChild(li);


### PR DESCRIPTION
While the signalling server will allocate unique identifiers for
each peer, users may want to also pass their own identifiers.