### PR TITLE
webrtcsink: reduce latency with vpx encoders

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -389,6 +389,7 @@ fn setup_encoding(
             enc.set_property("resize-allowed", true);
             enc.set_property("max-intra-bitrate", 250i32);
             enc.set_property_from_str("error-resilient", "default");
+            enc.set_property("lag-in-frames", 0i32);
             pay.set_property_from_str("picture-id-mode", "15-bit");
         }
         "x264enc" => {


### PR DESCRIPTION
The lag-in-frames property needs to be explicitly set to 0