### PR TITLE
webrtcsink: don't set msid-appdata on transceivers

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -998,8 +998,6 @@ impl Consumer {
             gst_webrtc::WebRTCRTPTransceiverDirection::Sendonly,
         );
 
-        transceiver.set_property("msid-appdata", stream.sink_pad.name());
-
         transceiver.set_property("codec-preferences", &payloader_caps);
 
         if stream.sink_pad.name().starts_with("video_") {


### PR DESCRIPTION
The change was merged inadvertently alongside the display-name
API extension, we will probably eventually expose API on webrtcsink
pads to control that, but we won't just set it to pad.name() anyway.

Fixes #33