### PR TITLE
webrtcsink: Fix a race starting the signaller

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -913,7 +913,7 @@ impl State {
 
     fn maybe_start_signaller(&mut self, element: &super::WebRTCSink) {
         if self.signaller_state == SignallerState::Stopped
-            && element.current_state() == gst::State::Playing
+            && element.current_state() >= gst::State::Paused
             && self.codec_discovery_done
         {
             if let Err(err) = self.signaller.start(element) {


### PR DESCRIPTION
1. Working scenario:

```
T1 -> Caps event (all caps have been received)
T1     -> Start discovering
T2 -> Change state to Playing
T2        -> The signaller is not started as:
                - Sink current_state() == Paused as it will be set to
                  playing after the change_state vmethod returns
                - Discovery is not done anyway
T1 -> Discovery is done
        => The signaller is started, and **everything works well**.
```

2. Failing scenario:

```
T1 -> Caps event (all caps have been received)
T1     -> Start discovering
T1 -> Discovery is done
T1        -> The signaller is not started as:
                - Current state == Paused (it will be set to playing
                  after the change_state vmethod returns)
                - Discovery is not done anyway
T2 -> Change state to Playing
T2        -> The signaller is not started as:
                - Sink current_state == Paused  as it will be set to
                  playing after the we return from the change_state
                  vmethod
```

In that case the signaller never starts.

---

The fix here is to ensure that the fact that we are going to PLAYING is
taken into account and we start the signaller right away.