### PR TITLE
Consumer pipeline should use_clock

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -1673,7 +1673,7 @@ impl WebRTCSink {
 
         let clock = element.clock();
 
-        pipeline.set_clock(clock.as_ref()).unwrap();
+        pipeline.use_clock(clock.as_ref()).unwrap();
         pipeline.set_start_time(gst::ClockTime::NONE);
         pipeline.set_base_time(element.base_time().unwrap());
 


### PR DESCRIPTION
As per private issue https://github.com/aivero-support/centricular-consulting/issues/26#issuecomment-1106602437
we should `use_clock()` instead of `set_clock()` on the consumer pipeline