### PR TITLE
Add support for VAAPI h.264 and VP8 encoder

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -330,6 +330,9 @@ fn configure_encoder(enc: &gst::Element) {
                 enc.set_property_from_str("rc-mode", "cbr-ld-hq");
                 enc.set_property("zerolatency", true);
             }
+            "vaapih264enc" => {
+                enc.set_property("bitrate", 2048u32);
+            }
             _ => (),
         }
     }
@@ -510,8 +513,8 @@ impl VideoEncoder {
     fn bitrate(&self) -> i32 {
         match self.factory_name.as_str() {
             "vp8enc" | "vp9enc" => self.element.property::<i32>("target-bitrate"),
-            "x264enc" | "nvh264enc" => (self.element.property::<u32>("bitrate") * 1000) as i32,
-            _ => unreachable!(),
+            "x264enc" | "nvh264enc" | "vaapih264enc" => (self.element.property::<u32>("bitrate") * 1000) as i32,
+            factory => unreachable!("Factory {} is currently not supported", factory),
         }
     }
 
@@ -532,10 +535,10 @@ impl VideoEncoder {
     fn set_bitrate(&mut self, element: &super::WebRTCSink, bitrate: i32) {
         match self.factory_name.as_str() {
             "vp8enc" | "vp9enc" => self.element.set_property("target-bitrate", bitrate),
-            "x264enc" | "nvh264enc" => self
+            "x264enc" | "nvh264enc" | "vaapih264enc" => self
                 .element
                 .set_property("bitrate", (bitrate / 1000) as u32),
-            _ => unreachable!(),
+            factory => unreachable!("Factory {} is currently not supported", factory),
         }
 
         let current_caps = self.filter.property::<gst::Caps>("caps");

--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -333,6 +333,7 @@ fn configure_encoder(enc: &gst::Element) {
             "vaapih264enc" | "vaapivp8enc" => {
                 enc.set_property("bitrate", 2048u32);
                 enc.set_property("keyframe-period", 2560u32);
+                enc.set_property_from_str("rate-control", "cbr");
             }
             _ => (),
         }

--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -330,8 +330,9 @@ fn configure_encoder(enc: &gst::Element) {
                 enc.set_property_from_str("rc-mode", "cbr-ld-hq");
                 enc.set_property("zerolatency", true);
             }
-            "vaapih264enc" => {
+            "vaapih264enc" | "vaapivp8enc" => {
                 enc.set_property("bitrate", 2048u32);
+                enc.set_property("keyframe-period", 2560u32);
             }
             _ => (),
         }
@@ -513,8 +514,10 @@ impl VideoEncoder {
     fn bitrate(&self) -> i32 {
         match self.factory_name.as_str() {
             "vp8enc" | "vp9enc" => self.element.property::<i32>("target-bitrate"),
-            "x264enc" | "nvh264enc" | "vaapih264enc" => (self.element.property::<u32>("bitrate") * 1000) as i32,
-            factory => unreachable!("Factory {} is currently not supported", factory),
+            "x264enc" | "nvh264enc" | "vaapih264enc" | "vaapivp8enc" => {
+                (self.element.property::<u32>("bitrate") * 1000) as i32
+            }
+            factory => unimplemented!("Factory {} is currently not supported", factory),
         }
     }
 
@@ -535,10 +538,10 @@ impl VideoEncoder {
     fn set_bitrate(&mut self, element: &super::WebRTCSink, bitrate: i32) {
         match self.factory_name.as_str() {
             "vp8enc" | "vp9enc" => self.element.set_property("target-bitrate", bitrate),
-            "x264enc" | "nvh264enc" | "vaapih264enc" => self
+            "x264enc" | "nvh264enc" | "vaapih264enc" | "vaapivp8enc" => self
                 .element
                 .set_property("bitrate", (bitrate / 1000) as u32),
-            factory => unreachable!("Factory {} is currently not supported", factory),
+            factory => unimplemented!("Factory {} is currently not supported", factory),
         }
 
         let current_caps = self.filter.property::<gst::Caps>("caps");


### PR DESCRIPTION
This fixes #50.
I am not sure what the effect of the other options in `configure_encoder` is so other improvements for tweaking latency etc might be possible.
Additionally I added a reason inside the `unreachable!` macro though I guess semantically a panic or whatever mechanism `gstreamer-rs` exposes to signal an error would be better.