### PR TITLE
Remove cd in usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ WEBRTCSINK_SIGNALLING_SERVER_LOG=debug cargo run --bin server
 In the second, run:
 
 ``` shell
-cd www
-python3 -m http.server
+python3 -m http.server -d www/
 ```
 
 In the third, run:


### PR DESCRIPTION
The `cd` did not serve any purpose which the pythons server does not already have so instead use that to save an instruction.
Instructions could be made even simpler when using background processes though that would hide any logs...

```shell
# Can be copy-pasted into a single shell
cargo run --bin server &>/dev/null &
python3 -m http.server -d www/ &>/dev/null &
gst-launch-1.0 --gst-plugin-path=$PWD v4l2src ! clockoverlay ! webrtcsink stun-server=null
```