### PR TITLE
Allow passing free form metadata about consumers/producers/listenners

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -10,27 +10,30 @@ pub enum RegisteredMessage {
     #[serde(rename_all = "camelCase")]
     Producer {
         peer_id: String,
-        display_name: Option<String>,
+        #[serde(default)]
+        meta: Option<serde_json::Value>,
     },
     /// Registered as a consumer
     #[serde(rename_all = "camelCase")]
     Consumer {
         peer_id: String,
-        display_name: Option<String>,
+        #[serde(default)]
+        meta: Option<serde_json::Value>,
     },
     /// Registered as a listener
     #[serde(rename_all = "camelCase")]
     Listener {
         peer_id: String,
-        display_name: Option<String>,
+        #[serde(default)]
+        meta: Option<serde_json::Value>,
     },
 }
-
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Peer {
     pub id: String,
-    pub display_name: Option<String>,
+    #[serde(default)]
+    pub meta: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -44,13 +47,15 @@ pub enum OutgoingMessage {
     #[serde(rename_all = "camelCase")]
     ProducerAdded {
         peer_id: String,
-        display_name: Option<String>,
+        #[serde(default)]
+        meta: Option<serde_json::Value>,
     },
     /// Notifies listeners that a producer was removed
     #[serde(rename_all = "camelCase")]
     ProducerRemoved {
         peer_id: String,
-        display_name: Option<String>,
+        #[serde(default)]
+        meta: Option<serde_json::Value>,
     },
     /// Instructs a peer to generate an offer
     #[serde(rename_all = "camelCase")]
@@ -75,19 +80,19 @@ pub enum RegisterMessage {
     #[serde(rename_all = "camelCase")]
     Producer {
         #[serde(default)]
-        display_name: Option<String>,
+        meta: Option<serde_json::Value>,
     },
     /// Register as a consumer
     #[serde(rename_all = "camelCase")]
     Consumer {
         #[serde(default)]
-        display_name: Option<String>,
+        meta: Option<serde_json::Value>,
     },
     /// Register as a listener
     #[serde(rename_all = "camelCase")]
     Listener {
         #[serde(default)]
-        display_name: Option<String>,
+        meta: Option<serde_json::Value>,
     },
 }
 

--- a/www/webrtc.js
+++ b/www/webrtc.js
@@ -342,16 +342,21 @@ function session_closed(peer_id) {
     sessions[peer_id] = null;
 }
 
-function addPeer(peer_id, display_name) {
-    console.log("Display name: ", display_name);
+function addPeer(peer_id, meta) {
+    console.log("Meta: ", JSON.stringify(meta));
 
     var nav_ul = document.getElementById("camera-list");
 
-    if (display_name == null) {
-        var li_str = '<li id="peer-' + peer_id + '"><button class="button button1">' + peer_id + '</button></li>';
-    } else {
-        var li_str = '<li id="peer-' + peer_id + '"><button class="button button1">' + display_name + '</button></li>';
+    meta = meta ? meta : {"display-name": peer_id};
+    let display_html = `${meta["display-name"] ? meta["display-name"] : peer_id}<ul>`;
+    for (const key in meta) {
+        if (key != "display-name") {
+            display_html += `<li>- ${key}: ${meta[key]}</li>`;
+        }
     }
+    display_html += "</ul>"
+
+    var li_str = '<li id="peer-' + peer_id + '"><button class="button button1">' + display_html + '</button></li>';
 
     nav_ul.insertAdjacentHTML('beforeend', li_str);
     var li = document.getElementById("peer-" + peer_id);
@@ -393,10 +398,10 @@ function onServerMessage(event) {
     } else if (msg.type == "list") {
         clearPeers();
         for (i = 0; i < msg.producers.length; i++) {
-            addPeer(msg.producers[i].id, msg.producers[i].displayName);
+            addPeer(msg.producers[i].id, msg.producers[i].meta);
         }
     } else if (msg.type == "producerAdded") {
-        addPeer(msg.peerId, msg.displayName);
+        addPeer(msg.peerId, msg.meta);
     } else if (msg.type == "producerRemoved") {
         var li = document.getElementById("peer-" + msg.peerId);
         li.parentNode.removeChild(li);


### PR DESCRIPTION
In some applications people might need to be able to pass more metadata
than the only "display-name" this commit allow that by adding a field in
all signalling structure where it is free form json.

On the "webrtcsink" side this commit adds a `meta` property as a
gst::Structure which will be passed as a json string to the signalling
server so we enforce data to be structured.