### PR TITLE
Fix max-bitrate property setter

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -2380,7 +2380,7 @@ impl ObjectImpl for WebRTCSink {
                 settings.cc_info.max_bitrate = (value.get::<u32>().expect("type checked upstream")
                     as f32
                     * if settings.do_fec {
-                        settings.cc_info.max_bitrate as f32 * 1.5
+                        1.5
                     } else {
                         1.
                     }) as u32;


### PR DESCRIPTION
`max-bitrate` was interpreted incorrectly when specified