### PR TITLE
gcc: Fix deadlock on shutdown

### DIFF
--- a/plugins/src/gcc/imp.rs
+++ b/plugins/src/gcc/imp.rs
@@ -1120,6 +1120,8 @@ impl BandwidthEstimator {
             } else {
                 let mut state = self.state.lock().unwrap();
                 state.flow_return = Err(gst::FlowError::Flushing);
+                drop(state);
+
                 self.srcpad.stop_task()?;
             }
 


### PR DESCRIPTION
We were holding the element .state lock while trying to shutdown leading
to a deadlock.

Fixes: https://github.com/centricular/webrtcsink/issues/90