### PR TITLE
Fix payloaders MTU to 1200

### DIFF
--- a/plugins/src/webrtcsink/imp.rs
+++ b/plugins/src/webrtcsink/imp.rs
@@ -468,6 +468,7 @@ fn setup_encoding(
         .with_context(|| format!("Creating payloader {}", codec.payloader.name()))?;
     let parse_filter = make_element("capsfilter", None)?;
 
+    pay.set_property("mtu", 1200 as u32);
     pay.set_property("pt", codec.payload as u32);
 
     if let Some(ssrc) = ssrc {


### PR DESCRIPTION
Higher value might be too big (in particular with many VPNs `webrtcsink` won't work with the default 1400 MTU).

1200 is the default value in libwebrtc and it is references in several places there.