### PR TITLE
signalling: Do not stop consuming sessions when a peer stops being a …

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -45,6 +45,9 @@ pub enum PeerRole {
     /// Register as a listener
     #[serde(rename_all = "camelCase")]
     Listener,
+
+    #[serde(skip)]
+    All,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]


### PR DESCRIPTION
…producer

This is a regression from: https://github.com/centricular/webrtcsink/pull/93