### PR TITLE
gcc: Only log error when pausing task failes

### DIFF
--- a/plugins/src/gcc/imp.rs
+++ b/plugins/src/gcc/imp.rs
@@ -1054,7 +1054,7 @@ impl BandwidthEstimator {
         self.srcpad.start_task(move || {
             let pause = || {
                 if let Some(pad) = weak_pad.upgrade() {
-                    pad.pause_task().unwrap();
+                    let _ = pad.pause_task();
                 }
             };
             let bwe = weak_bwe


### PR DESCRIPTION
We can't do much about it at this point

Fixes https://github.com/centricular/webrtcsink/issues/110