### PR TITLE
signalling: fix -h flag parsing

### DIFF
--- a/signalling/src/bin/server.rs
+++ b/signalling/src/bin/server.rs
@@ -15,7 +15,7 @@ use tracing::{info, warn};
 /// Program arguments
 struct Args {
     /// Address to listen on
-    #[clap(short, long, default_value = "0.0.0.0")]
+    #[clap(long, default_value = "0.0.0.0")]
     host: String,
     /// Port to listen on
     #[clap(short, long, default_value_t = 8443)]


### PR DESCRIPTION
Looks like after recent `clap` update, it now panics _(at least in debug)_ due to non-unique arguments (`-h` comes by both `host` and `help`).
`-h` for help seems to be more reasonable imo, so I suggest to remove short flag for host. Or we can make it different. Please suggest if you have better idea.

```shell
$ cargo run --bin server
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/server`
thread 'main' panicked at 'Command webrtcsink-signalling: Short option names must be unique for each argument, but '-h' is in use by both 'host' and 'help' (call `cmd.disable_help_flag(true)` to remove the auto-generated `--help`)', /Users/nazar/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.0.16/src/builder/debug_asserts.rs:121:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```